### PR TITLE
remove target="_blank" from information <a> tag

### DIFF
--- a/themes/eleventhirty.am/views/index.html
+++ b/themes/eleventhirty.am/views/index.html
@@ -58,7 +58,7 @@
                 <a title="Show Playlists [P]" href="javascript:void(0)" id="togglePlaylistShow" data-action="togglePlaylistShow"><span class="iconicstroke-list"></span></a>
                 <a title="Shuffle [S]" href="javascript:void(0)" id="toggleShuffle" data-action="toggleShuffle"><span class="iconicstroke-fork"></span></a>
                 <a title="Show Player [V]" href="javascript:void(0)" id="togglePlayerShow" data-action="togglePlayerShow"><span class="iconicstroke-eye"></span></a>
-                <a title="Show information [I]" target="_blank" href="javascript:void(0)" id="toggleInfoShow" data-action="toggleInfoShow" ><span class="iconicstroke-info"></span></a>
+                <a title="Show information [I]" href="javascript:void(0)" id="toggleInfoShow" data-action="toggleInfoShow" ><span class="iconicstroke-info"></span></a>
                 <br /><br />
                 <p id="mobilewarning">Mobile devices might have trouble auto-starting media. Click the eye icon and start by hand if this is the case for you.</p>
                 <div id="extras">

--- a/themes/latenight.blue/views/index.html
+++ b/themes/latenight.blue/views/index.html
@@ -60,7 +60,7 @@
                 <a title="Show Playlists [P]" href="javascript:void(0)" id="togglePlaylistShow" data-action="togglePlaylistShow"><span class="iconicstroke-list"></span></a>
                 <a title="Shuffle [S]" href="javascript:void(0)" id="toggleShuffle" data-action="toggleShuffle"><span class="iconicstroke-fork"></span></a>
                 <a title="Show Player [V]" href="javascript:void(0)" id="togglePlayerShow" data-action="togglePlayerShow"><span class="iconicstroke-eye"></span></a>
-                <a title="Show information [I]" target="_blank" href="javascript:void(0)" id="toggleInfoShow" data-action="toggleInfoShow" ><span class="iconicstroke-info"></span></a>
+                <a title="Show information [I]" href="javascript:void(0)" id="toggleInfoShow" data-action="toggleInfoShow" ><span class="iconicstroke-info"></span></a>
                 <br /><br />
                 <p id="mobilewarning">Mobile devices might have trouble auto-starting media. Click the eye icon and start by hand if this is the case for you.</p>
                 <div id="extras">


### PR DESCRIPTION
Currently, both themes have target="_blank" on the "Show Information" <a> tag, causing a new empty tab to be opened when you click on it in firefox.
